### PR TITLE
feat: remove Contributors section from release template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -48,8 +48,6 @@ version-resolver:
   default: patch
 template: |
   $CHANGES
-
-  $CONTRIBUTORS
 autolabeler:
   - label: "chore"
     title:


### PR DESCRIPTION
## Summary

Removes the `$CONTRIBUTORS` section from the release-drafter template. This section was previously removed in PR #22 but was accidentally re-added in PR #23 when that branch was based on an older version of main.

## Review & Testing Checklist for Human

- [ ] Verify the YAML syntax is still valid (the template section should just have `$CHANGES` now)
- [ ] After merge, check that the next draft release doesn't include a Contributors section

**Test plan**: Merge this PR and verify the v0.1.4 draft release (or next draft) no longer shows the Contributors section.

### Notes

- Requested by: @aaronsteers (AJ Steers, aj@airbyte.io)
- Devin session: https://app.devin.ai/sessions/64ab57ea66014c32b331079f2aac0cca