### PR TITLE
ci: fix release drafter race condition

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts the next Release notes as Pull Requests are merged into "main"
-      # Pinned to v6.0.0 to avoid v6.1.0 bug (release-drafter/release-drafter#1425)
+      # Pinned to v6.0.0 to avoid v6.1.0 bug: https://github.com/release-drafter/release-drafter/issues/1425
       - uses: release-drafter/release-drafter@v6.0.0
         id: release-drafter
         with:


### PR DESCRIPTION
## Summary

Fixes a race condition where merged PRs sometimes don't appear in the draft release notes (rerunning the action fixes it). This was identified as affecting multiple Airbyte repos.

**Changes:**
1. Add `concurrency` group with `cancel-in-progress: false` to queue (not cancel) overlapping runs when multiple PRs merge in quick succession
2. Pin to `@v6.0.0` to avoid v6.1.0 bug ([release-drafter/release-drafter#1425](https://github.com/release-drafter/release-drafter/issues/1425)) where the action fails to find existing draft releases and creates duplicates

## Review & Testing Checklist for Human

- [ ] Verify [release-drafter#1425](https://github.com/release-drafter/release-drafter/issues/1425) is still open before merging
- [ ] After merging, test by merging 2-3 PRs in quick succession and verify all appear in the draft release

### Notes

- Requested by: AJ Steers (@aaronsteers)
- Link to Devin run: https://app.devin.ai/sessions/bfdf3cd3e5ad4650be584a525be6d258