### PR TITLE
ci: skip validate-pr-title when only description edited

### DIFF
--- a/.github/workflows/semantic-pr-check.yml
+++ b/.github/workflows/semantic-pr-check.yml
@@ -61,6 +61,13 @@ jobs:
 
   validate-pr-title:
     name: Validate PR Title
+    # Skip if 'edited' event but the title wasn't changed (e.g., only description was edited)
+    if: >
+      github.event.action != 'edited'
+      || (
+        github.event.changes.title &&
+        github.event.changes.title.from != ''
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Check semantic PR title


### PR DESCRIPTION
## Summary

Applies the same optimization from the `autolabel` job to the `validate-pr-title` job. The job now skips when a PR is edited but only the description changed (not the title), since there's no need to re-validate a title that hasn't changed.

This uses the same condition pattern already merged and tested in PR #28:
```yaml
if: >
  github.event.action != 'edited'
  || (
    github.event.changes.title &&
    github.event.changes.title.from != ''
  )
```

## Review & Testing Checklist for Human

- [ ] Verify the condition logic matches the autolabel job's condition (should be identical)
- [ ] Test by editing only a PR description - the "Validate PR Title" job should be skipped

**Test plan:** Edit only the description of a test PR and verify the Validate PR Title job shows as skipped. Then edit the title and verify the job runs.

### Notes

- Requested by: @aaronsteers (AJ Steers, aj@airbyte.io)
- Devin session: https://app.devin.ai/sessions/64ab57ea66014c32b331079f2aac0cca