### PR TITLE
ci: add step to delete existing release assets before upload

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -45,10 +45,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Delete all existing assets to ensure clean replacement
-      # This prevents stale artifacts from accumulating if package name changes
       - name: Delete existing release assets
         uses: andreaswilli/delete-release-assets-action@v4.0.0
+        # Delete all existing assets to ensure clean replacement
+        # This prevents stale artifacts from accumulating, e.g. if artifact names change
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ needs.update_release_draft.outputs.tag_name }}


### PR DESCRIPTION
## Summary

Adds a step to delete all existing release assets before uploading new ones in the release-drafter workflow. This prevents stale artifacts from accumulating if the package name changes.

**Context:** During the fastmcp-extensions v0.1.0 release, the package was renamed from `awesome_python_template` to `fastmcp_extensions`. The existing `overwrite: true` option only overwrites files with the same name, so both old and new artifacts ended up in the release, causing the PyPI publish to fail.

Uses `andreaswilli/delete-release-assets-action@v4.0.0` with `deleteOnlyFromDrafts: true` to safely delete assets only from draft releases.

## Review & Testing Checklist for Human

- [ ] Verify the third-party action `andreaswilli/delete-release-assets-action` is acceptable (4 stars, MIT license, simple codebase)
- [ ] Confirm `deleteOnlyFromDrafts: true` prevents accidental deletion of published release assets
- [ ] After merging, verify the release-drafter workflow runs successfully on the next push to main

### Notes

Requested by: @aaronsteers
Devin session: https://app.devin.ai/sessions/1fb5bdafcca747329006c5d526701a8c