### PR TITLE
ci: add pull_request trigger for release-drafter autolabeler

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 concurrency:
-  group: release-drafter
-  cancel-in-progress: false
+  group: release-drafter-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
## Summary

Fixes release-drafter not grouping PRs into categories by adding the `pull_request` trigger. The autolabeler feature requires this trigger to apply labels when PRs are opened/updated - without it, PRs never get labels, so release notes show all items ungrouped.

Also updates the concurrency group to be event-specific, preventing PR runs from blocking push-to-main runs.

## Review & Testing Checklist for Human

- [ ] Verify that the release-drafter action only runs the autolabeler (not release draft updates) on `pull_request` events - check [release-drafter docs](https://github.com/release-drafter/release-drafter#autolabeler)
- [ ] Test by opening a PR with a conventional commit title (e.g., `feat: test`) and confirm the appropriate label is applied automatically
- [ ] After merging, verify the next release draft groups items correctly under category headers

### Notes

Requested by: @aaronsteers
Devin session: https://app.devin.ai/sessions/7e4f7a26a67248bf8d475999269a07c3