### PR TITLE
ci: add fail-hard behavior and workflow_dispatch label creation to autolabeler

### DIFF
--- a/.github/workflows/semantic-pr-check.yml
+++ b/.github/workflows/semantic-pr-check.yml
@@ -10,12 +10,23 @@
 #
 # Note: The autolabeler uses the same release-drafter.yml config but only applies
 # labels when triggered from PR events (it doesn't create/update draft releases).
+#
+# Manual Usage (workflow_dispatch):
+#   Run this workflow manually with `create_labels: true` to create any missing
+#   labels required by the autolabeler. This is useful after creating a new repo
+#   from a template.
 
 name: Semantic PR Title Validation
 
 on:
   pull_request:
     types: [opened, edited, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      create_labels:
+        description: 'Create missing labels required by the autolabeler'
+        type: boolean
+        default: false
 
 jobs:
   autolabel:
@@ -25,7 +36,8 @@ jobs:
     # Skipping unnecessary runs reduces unlabel-relabel spam on the PR.
     # Some notification triggers run upon label additions, so this also prevents notification spam.
     if: >
-      github.event.action != 'edited'
+      github.event_name == 'workflow_dispatch'
+      || github.event.action != 'edited'
       || (
         github.event.changes.title &&
         github.event.changes.title.from != ''
@@ -34,10 +46,50 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     steps:
+      # Create missing labels if requested via workflow_dispatch
+      - name: Create missing labels
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.create_labels }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = [
+              { name: 'bug', color: 'd73a4a', description: 'Something isn\'t working' },
+              { name: 'enhancement', color: 'a2eeef', description: 'New feature or request' },
+              { name: 'chore', color: 'ededed', description: 'Maintenance tasks' },
+              { name: 'ci', color: 'ededed', description: 'CI/CD changes' },
+              { name: 'docs', color: 'ededed', description: 'Documentation changes' },
+              { name: 'testing', color: 'ededed', description: 'Test-related changes' },
+              { name: 'security', color: 'ededed', description: 'Security-related changes' },
+              { name: 'dependencies', color: '0366d6', description: 'Dependency updates' },
+              { name: 'breaking', color: 'b60205', description: 'Breaking changes' },
+            ];
+
+            for (const label of labels) {
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color: label.color,
+                  description: label.description,
+                });
+                console.log(`Created label: ${label.name}`);
+              } catch (error) {
+                if (error.status === 422) {
+                  console.log(`Label already exists: ${label.name}`);
+                } else {
+                  throw error;
+                }
+              }
+            }
+            console.log('All required labels are now configured.');
+
       # Remove title-derived labels first to make autolabeler idempotent
       # (e.g., if PR title changes from "fix:" to "ci:", remove old "bug" label)
       - name: Remove title-derived labels
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           labels: |
@@ -50,14 +102,37 @@ jobs:
             security
             dependencies
             breaking
+          fail_on_error: true
 
       # Run release-drafter with disable-releaser to only apply labels (not create releases)
-      - uses: release-drafter/release-drafter@v6
+      - name: Apply label based on PR title
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: release-drafter/release-drafter@v6
         with:
           config-name: release-drafter.yml
           disable-releaser: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Verify that a label was applied - fail if not
+      - name: Verify label was applied
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const expectedLabels = ['bug', 'enhancement', 'chore', 'ci', 'docs', 'testing', 'security', 'dependencies', 'breaking'];
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            const prLabels = pr.labels.map(l => l.name);
+            const hasExpectedLabel = expectedLabels.some(label => prLabels.includes(label));
+            if (!hasExpectedLabel) {
+              core.setFailed(`No autolabel was applied to this PR. This usually means the required labels don't exist in the repository. Run this workflow manually with 'create_labels: true' to create them.`);
+            } else {
+              console.log(`PR has label(s): ${prLabels.filter(l => expectedLabels.includes(l)).join(', ')}`);
+            }
 
   validate-pr-title:
     name: Validate PR Title


### PR DESCRIPTION
## Summary

This PR addresses a silent failure mode in the autolabeler where missing repository labels caused the workflow to succeed without actually applying labels. The changes add two key improvements:

1. **Fail-hard behavior**: The workflow now fails explicitly when labeling is unsuccessful, with a clear error message directing users to create the missing labels
2. **Manual label creation**: Added `workflow_dispatch` trigger with a `create_labels` input that allows users to create all required labels by running the workflow manually

This is particularly useful for repos created from this template, where the required labels (bug, enhancement, chore, ci, docs, testing, security, dependencies, breaking) may not exist.

## Review & Testing Checklist for Human

- [ ] **Verify `fail_on_error: true` behavior**: The remove-labels step now has `fail_on_error: true`. Confirm this won't cause false failures when trying to remove labels that were never applied (vs. labels that don't exist in the repo)
- [ ] **Test the verify step logic**: The "Verify label was applied" step fails if no expected label is present. Consider: what happens if a PR title doesn't match any autolabeler pattern (e.g., `refactor:`)? Should this fail or is that intentional?
- [ ] **Label list consistency**: The hardcoded label list appears in both "Create missing labels" and "Verify label was applied" steps. Cross-check these match the labels in `release-drafter.yml`

**Recommended test plan:**
1. Merge this PR
2. Run the workflow manually via Actions → "Semantic PR Title Validation" → Run workflow with `create_labels: true` (on a test repo or this one)
3. Open a test PR with a semantic title (e.g., `feat: test`) and verify the autolabel is applied
4. Open a test PR with a non-matching title and verify the workflow fails with the expected error message

### Notes

Requested by: @aaronsteers
Devin session: https://app.devin.ai/sessions/7e4f7a26a67248bf8d475999269a07c3