### PR TITLE
fix: upload docs from module subdirectory for GitHub Pages

### DIFF
--- a/.github/workflows/docs-generate.yml
+++ b/.github/workflows/docs-generate.yml
@@ -39,11 +39,15 @@ jobs:
       - name: Build documentation
         run: uv run poe docs-generate
 
+      - name: Get generated docs directory
+        id: docs-dir
+        run: echo "path=$(uv run poe -q get-generated-docs-dir)" >> $GITHUB_OUTPUT
+
       - name: Upload docs artifacts
         uses: actions/upload-artifact@v4
         with:
           name: docs-${{ github.run_id }}
-          path: docs/generated/
+          path: ${{ steps.docs-dir.outputs.path }}
 
       - name: Setup Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -53,7 +57,7 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/generated
+          path: ${{ steps.docs-dir.outputs.path }}
 
   deploy:
     name: Publish Docs

--- a/poe_tasks.toml
+++ b/poe_tasks.toml
@@ -30,6 +30,7 @@ build = "uv build"
 # Documentation with pdoc3
 docs-generate = "pdoc --html --output-dir docs/generated ${SRC_MODULE} --force"
 docs-preview = { shell = "pdoc --html --output-dir docs/generated ${SRC_MODULE} --force && open docs/generated/${SRC_MODULE}/index.html" }
+get-generated-docs-dir = "echo docs/generated/${SRC_MODULE}"
 
 # Development helpers
 clean = "rm -rf .pytest_cache .coverage htmlcov dist .ruff_cache"


### PR DESCRIPTION
## Summary

Fixes the GitHub Pages 404 issue at the root URL (https://aaronsteers.github.io/awesome-python-template/) by uploading docs from the module subdirectory instead of the parent `docs/generated/` folder.

**Changes:**
- Adds `get-generated-docs-dir` poe task that echoes `docs/generated/${SRC_MODULE}`
- Updates CI workflow to use this task (with `-q` flag for clean output) to determine the upload path

## Review & Testing Checklist for Human

- [ ] Verify the `get-generated-docs-dir` task outputs correctly: run `uv run poe -q get-generated-docs-dir` and confirm it outputs `docs/generated/awesome_python_template` with no extra text
- [ ] After merge, verify the root GitHub Pages URL works: https://aaronsteers.github.io/awesome-python-template/
- [ ] Check the "Build Docs" CI job logs to confirm the path is captured correctly in `$GITHUB_OUTPUT`

**Suggested test plan:**
1. Merge this PR
2. Wait for the "Publish Docs" job to complete on main
3. Navigate to https://aaronsteers.github.io/awesome-python-template/ and verify it loads the docs (instead of 404)

### Notes

Requested by @aaronsteers

Link to Devin run: https://app.devin.ai/sessions/7fb1c1416ef0443f8bd01da628d6fdc2