### PR TITLE
ci: migrate to semantic-pr-release-drafter@v0.3.0

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,9 +1,0 @@
-# Release Drafter Configuration
-# See: https://github.com/aaronsteers/semantic-pr-release-drafter/issues/1
-
-name-template: "v$RESOLVED_VERSION"
-tag-template: "v$RESOLVED_VERSION"
-change-template: "- $TITLE (#$NUMBER)"
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-template: |
-  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,12 +17,8 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      # Drafts the next Release notes as Pull Requests are merged into "main"
-      # See: https://github.com/aaronsteers/semantic-pr-release-drafter/issues/1
-      - uses: aaronsteers/semantic-pr-release-drafter@devin/1768702956-semantic-pr-release-p1
+      - uses: aaronsteers/semantic-pr-release-drafter@v0.3.0
         id: release-drafter
-        with:
-          config-name: release-drafter.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

Migrates from a development branch of semantic-pr-release-drafter to the stable v0.3.0 release and removes the custom configuration file, using the action's built-in defaults instead.

Changes:
- Updated action from `@devin/1768702956-semantic-pr-release-p1` to `@v0.3.0`
- Deleted `.github/release-drafter.yml` custom config
- Removed `config-name` parameter (action now uses defaults)

## Review & Testing Checklist for Human

- [ ] Verify the action's default release note templates are acceptable for this repo (previously used custom `name-template`, `tag-template`, `change-template`)
- [ ] After merging, monitor the next PR merge to confirm release draft is generated correctly

### Notes

This is part of a batch migration across multiple repos to standardize on the stable release of semantic-pr-release-drafter.

Requested by: @aaronsteers
Link to Devin run: https://app.devin.ai/sessions/dbf7f70cc98d47b89f304541608046fa