### PR TITLE
ci: simplify release-drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,6 +1,7 @@
 name: Release Drafter
 
 on:
+  workflow_dispatch: {}
   push:
     branches:
       - main
@@ -10,44 +11,24 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  update_release_draft:
-    # Only runs on push to main - creates/updates draft release notes
+  draft_release:
+    name: Draft Release
     permissions:
       contents: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: aaronsteers/semantic-pr-release-drafter@v0.3.0
+      - name: Create or update draft release
+        uses: aaronsteers/semantic-pr-release-drafter@v0.3.1
         id: release-drafter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    outputs:
-      upload_url: ${{ steps.release-drafter.outputs.upload_url }}
-      tag_name: ${{ steps.release-drafter.outputs.tag_name }}
-      release_id: ${{ steps.release-drafter.outputs.id }}
-
-  # Build and upload assets to the draft release (only on push to main)
-  upload_release_assets:
-    name: Upload Release Assets
-    needs: [update_release_draft]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
       - name: Delete existing release assets
         uses: andreaswilli/delete-release-assets-action@v4.0.0
-        # Delete all existing assets to ensure clean replacement
-        # This prevents stale artifacts from accumulating, e.g. if artifact names change
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ needs.update_release_draft.outputs.tag_name }}
+          tag: ${{ steps.release-drafter.outputs.tag_name }}
           deleteOnlyFromDrafts: true
 
       - name: Install uv
@@ -55,41 +36,22 @@ jobs:
         with:
           version: "latest"
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Checkout Repo
+        uses: actions/checkout@v6
         with:
-          python-version: "3.12"
-
-      - name: Get version from draft release tag
-        id: version
-        run: |
-          TAG_NAME="${{ needs.update_release_draft.outputs.tag_name }}"
-          # Remove 'v' prefix if present
-          VERSION="${TAG_NAME#v}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Building version: $VERSION"
+          fetch-depth: 0
 
       - name: Build package
         env:
-          UV_DYNAMIC_VERSIONING_BYPASS: ${{ steps.version.outputs.version }}
-        run: uv build
+          TAG_NAME: ${{ steps.release-drafter.outputs.tag_name }}
+        run: UV_DYNAMIC_VERSIONING_BYPASS="${TAG_NAME#v}" uv build
 
-      - name: Upload wheel to draft release
+      - name: Upload assets to draft release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/*.whl
-          release_id: ${{ needs.update_release_draft.outputs.release_id }}
-          overwrite: true
-          file_glob: true
-          draft: true
-
-      - name: Upload sdist to draft release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/*.tar.gz
-          release_id: ${{ needs.update_release_draft.outputs.release_id }}
+          file: dist/*.{whl,tar.gz}
+          release_id: ${{ steps.release-drafter.outputs.id }}
           overwrite: true
           file_glob: true
           draft: true


### PR DESCRIPTION
## Summary

Simplifies the release-drafter workflow by consolidating two jobs into one and removing redundant steps. This pattern was tested and verified working in [airbytehq/fastmcp-extensions#12](https://github.com/airbytehq/fastmcp-extensions/pull/12).

Key changes:
- Combine `update_release_draft` and `upload_release_assets` jobs into single `draft_release` job
- Remove `setup-python` step (uv manages its own Python)
- Simplify version resolution using inline bash parameter expansion (`${TAG_NAME#v}`)
- Combine wheel/sdist uploads into single step using brace expansion glob (`dist/*.{whl,tar.gz}`)
- Add `workflow_dispatch` trigger for manual runs
- Update semantic-pr-release-drafter to v0.3.1

Reduces workflow from 96 lines to 58 lines.

## Review & Testing Checklist for Human

- [ ] Verify the brace expansion glob `dist/*.{whl,tar.gz}` uploads only wheel and sdist (not `.gitignore` that uv creates in dist/)
- [ ] Merge and watch the Release Drafter workflow run on next push to main to confirm assets are uploaded correctly

**Test plan:** Merge this PR, then push any change to main and verify the Release Drafter workflow creates a draft release with both `.whl` and `.tar.gz` assets attached.

### Notes

This is a backport of the pattern tested in [airbytehq/fastmcp-extensions#12](https://github.com/airbytehq/fastmcp-extensions/pull/12), where the workflow successfully created draft release v0.1.2 with correct assets.

Requested by: @aaronsteers  
Devin session: https://app.devin.ai/sessions/156b0420198e44ed8bc3817334eda185