### PR TITLE
ci: update semantic-pr-release-drafter to v0.4 with attach-files feature

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,19 +18,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - name: Create or update draft release
-        uses: aaronsteers/semantic-pr-release-drafter@v0.3.1
-        id: release-drafter
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Delete existing release assets
-        uses: andreaswilli/delete-release-assets-action@v4.0.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ steps.release-drafter.outputs.tag_name }}
-          deleteOnlyFromDrafts: true
-
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -42,16 +29,14 @@ jobs:
           fetch-depth: 0
 
       - name: Build package
-        env:
-          TAG_NAME: ${{ steps.release-drafter.outputs.tag_name }}
-        run: UV_DYNAMIC_VERSIONING_BYPASS="${TAG_NAME#v}" uv build
+        run: uv build
 
-      - name: Upload assets to draft release
-        uses: svenstaro/upload-release-action@v2
+      - name: Create or update draft release
+        uses: aaronsteers/semantic-pr-release-drafter@v0.4
+        id: release-drafter
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/*.{whl,tar.gz}
-          release_id: ${{ steps.release-drafter.outputs.id }}
-          overwrite: true
-          file_glob: true
-          draft: true
+          attach-files: |
+            dist/*.whl
+            dist/*.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Updates `semantic-pr-release-drafter` from v0.3.1 to v0.4 and simplifies the release workflow by using the new `attach-files` input for idempotent asset management. This replaces three separate actions (release drafter + delete assets + upload assets) with a single action call.

Key changes:
- Removed `andreaswilli/delete-release-assets-action` step
- Removed `svenstaro/upload-release-action` step
- Added `attach-files` input to handle asset upload with automatic deletion of existing assets
- Reordered steps: build now happens before release drafter so artifacts exist when attaching

## Review & Testing Checklist for Human

- [ ] **Verify package versioning still works** - The `UV_DYNAMIC_VERSIONING_BYPASS="${TAG_NAME#v}"` was removed from the build step. Confirm that `uv build` without this override produces packages with correct version numbers (this may depend on how dynamic versioning is configured in pyproject.toml)
- [ ] **Test the workflow end-to-end** - Trigger the workflow manually via `workflow_dispatch` and verify:
  1. Package builds successfully
  2. Draft release is created/updated
  3. `.whl` and `.tar.gz` files are attached to the draft release
- [ ] **Verify idempotency** - Run the workflow twice and confirm the release has exactly the expected assets (no duplicates)

### Notes

The `attach-files` feature in v0.4 was just merged in [PR #21](https://github.com/aaronsteers/semantic-pr-release-drafter/pull/21). This is its first real-world usage.

**Requested by:** @aaronsteers  
**Devin session:** https://app.devin.ai/sessions/8c31f6ca523e48229d69718c48a05389