### PR TITLE
docs: add Releasing section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,3 +21,7 @@ View all available tasks:
 ```bash
 poe --help
 ```
+
+## Releasing
+
+This project uses [`semantic-pr-release-drafter`](https://github.com/aaronsteers/semantic-pr-release-drafter) for automated release management. For full details on how releases work, see the [Releasing Guide](https://github.com/aaronsteers/semantic-pr-release-drafter/blob/main/docs/releasing.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,8 @@ View all available tasks:
 poe --help
 ```
 
-## Releasing
+## 🚀 Releasing
 
-This project uses [`semantic-pr-release-drafter`](https://github.com/aaronsteers/semantic-pr-release-drafter) for automated release management. For full details on how releases work, see the [Releasing Guide](https://github.com/aaronsteers/semantic-pr-release-drafter/blob/main/docs/releasing.md).
+This project uses [`semantic-pr-release-drafter`](https://github.com/aaronsteers/semantic-pr-release-drafter) for automated release management. To release, simply click "`Edit`" on the latest release draft from the [releases page](https://github.com/aaronsteers/awesome-python-template/releases), and then click "`Publish release`". This publish operation will trigger all necessary downstream publish operations.
+
+ℹ️ For more detailed instructions, please see the [Releasing Guide](https://github.com/aaronsteers/semantic-pr-release-drafter/blob/main/docs/releasing.md).


### PR DESCRIPTION
# docs: add Releasing section to CONTRIBUTING.md

## Summary

Adds a `## 🚀 Releasing` section to `CONTRIBUTING.md` with:
- Inline release instructions (click "Edit" on the latest draft from the [releases page](https://github.com/aaronsteers/awesome-python-template/releases), then "Publish release")
- A link to the shared [Releasing Guide](https://github.com/aaronsteers/semantic-pr-release-drafter/blob/main/docs/releasing.md) in `semantic-pr-release-drafter` for more detailed instructions

Part of a cross-repo effort to ensure all repos using `semantic-pr-release-drafter` have a consistent "Releasing" entry in their CONTRIBUTING.md. The upstream docs PR is [aaronsteers/semantic-pr-release-drafter#41](https://github.com/aaronsteers/semantic-pr-release-drafter/pull/41).

### Updates since last revision
- Revised release instruction text per reviewer feedback (corrected sentence structure)
- Added 🚀 emoji to section heading
- Added repo-specific [releases page](https://github.com/aaronsteers/awesome-python-template/releases) link so users can go directly to drafts
- Added ℹ️ prefix to the detailed guide link

## Review & Testing Checklist for Human

- [ ] **Verify the releases page link points to the correct repo.** The link should go to [awesome-python-template/releases](https://github.com/aaronsteers/awesome-python-template/releases), not another repo.
- [ ] **Verify the Releasing Guide link resolves.** The [Releasing Guide](https://github.com/aaronsteers/semantic-pr-release-drafter/blob/main/docs/releasing.md) is being added in [aaronsteers/semantic-pr-release-drafter#41](https://github.com/aaronsteers/semantic-pr-release-drafter/pull/41) — that PR should be merged first (or simultaneously) so the link isn't broken on `main`.

### Notes

- Docs-only change, no code or workflow modifications.
- Identical sibling PRs are open across all other consumer repos (fastmcp-extensions, PyAirbyte, airbyte-python-cdk, terraform-provider-airbyte, devin-action, devin-reminders-action, tk-todo-check-action, zenbyte-app-internal).

---
Requested by: @aaronsteers
[Devin session](https://app.devin.ai/sessions/d59fa353515f488ab1818b8888d0c3bf)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aaronsteers/awesome-python-template/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
