### PR TITLE
ci(release-drafter): adopt not-ready 3-step workflow, upgrade to v2.1.0

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Create draft release (not ready)
         uses: aaronsteers/semantic-pr-release-drafter@v2.1.0
-        id: draft
+        id: not-ready-draft
         with:
           not-ready: true
         env:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -28,21 +28,22 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Build package
-        run: uv build
-
-      - name: Create draft release with assets (not ready)
+      - name: Create draft release (not ready)
         uses: aaronsteers/semantic-pr-release-drafter@v2.1.0
-        id: release-drafter
+        id: draft
         with:
           not-ready: true
-          attach-files: |
-            dist/*.whl
-            dist/*.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Finalize draft release (remove banner)
+      - name: Build package
+        run: uv build
+
+      - name: Attach assets and finalize draft
         uses: aaronsteers/semantic-pr-release-drafter@v2.1.0
+        with:
+          attach-files: |
+            dist/*.whl
+            dist/*.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -31,12 +31,18 @@ jobs:
       - name: Build package
         run: uv build
 
-      - name: Create or update draft release
-        uses: aaronsteers/semantic-pr-release-drafter@v0.4.0
+      - name: Create draft release with assets (not ready)
+        uses: aaronsteers/semantic-pr-release-drafter@v2.1.0
         id: release-drafter
         with:
+          not-ready: true
           attach-files: |
             dist/*.whl
             dist/*.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Finalize draft release (remove banner)
+        uses: aaronsteers/semantic-pr-release-drafter@v2.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Upgrades `semantic-pr-release-drafter` from `v0.4.0` to `v2.1.0` and adopts the new `not-ready` input to prevent admins from publishing a draft release while file assets are still being uploaded.

New flow (Pattern B — 2 calls to release-drafter):
```
not-ready: true (create draft with banner) → build → attach-files (finalize, banner removed)
```

Depends on aaronsteers/semantic-pr-release-drafter#54 being released as v2.1.0.

Requested by @aaronsteers.

Link to Devin session: https://app.devin.ai/sessions/601932cfa6b54ec8a6145cd9300d43aa